### PR TITLE
When widgets have key they should be validated by key and not be id

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,6 +17,11 @@ repeating_widget = twc.RepeatingWidget(id='a', child=
     twc.Widget(validator=twc.Validator(required=True))
 )
 
+compound_keyed_widget = twc.CompoundWidget(id='a', children=[
+    twc.Widget(id='b', key='x', validator=twc.Validator(required=True)),
+    twc.Widget(id='c', key='y', validator=formencode.validators.OpenId()),
+])
+
 class TestValidationError(tb.WidgetTest):
     def test_validator_msg(self):
         twc.core.request_local = tb.request_local_tst
@@ -105,7 +110,6 @@ class TestValidation(object):
         except ValidationError, ve:
             assert(ve.widget.error_msg == NeverValid.msgs['never'])
         
-
     def test_auto_unflatten(self):
         test = twc.CompoundWidget(id='a', children=[
             twc.Widget(id='b', validator=twc.Validator(required=True)),
@@ -205,6 +209,14 @@ class TestValidation(object):
 
     def test_compound_whole_validator(self):
         pass # TBD
+
+    def test_compound_keyed_children(self):
+        testapi.request(1)
+        inp = {'a': {'x':'test', 'y':'test2'}}
+        try:
+            compound_keyed_widget.validate(inp)
+        except twc.ValidationError, e:
+            assert "is not a valid OpenId" in str(e)
 
     def test_rw_pass(self):
         testapi.request(1)

--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -611,7 +611,7 @@ class CompoundWidget(Widget):
             try:
                 if c._sub_compound:
                     data.update(c._validate(value, data))
-                elif hasattr(c, 'id'):
+                elif hasattr(c, 'id') and c.id not in self.keyed_children:
                     val = c._validate(value.get(c.id), data)
                     if val is not vd.EmptyField:
                         data[c.id] = val


### PR DESCRIPTION
Issue came up on IRC while porting sprox to tw2 as sprox uses sx_[_] as the field id and [_] as the key due to the fact that is might have fields named starting with an "_" which would result in an invalid id.

[22:19]  <amol> widgets are filled with values using the widget key
[22:19]  <amol> but then they are validated using the id to lookup the value
[22:19]  <amol> by default id and key equals
[22:19]  <amol> but in my case I have ids which are different from keys
[22:20]  <amol> and so validation fails as the parameter is user_name but it looks for sx_user_name which is the id
[22:32]  <amol> uhm, after validating by id it revalidates by keys, so the idea is probably that the value is overidden by its key version
[22:32]  <amol> the issue is that actually the validator crashes when it gets None
