### PR TITLE
Avoid receiving None instead of the object itself when object evaluates to False

### DIFF
--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -359,7 +359,7 @@ class Widget(pm.Parametered):
         """
 
         # Support backwards compatibility with tw1-style calling
-        if value and 'value' not in kw:
+        if value is not None and 'value' not in kw:
             kw['value'] = value
 
         if not self:


### PR DESCRIPTION
When passing a value where the object evalutes to false, like an empty list or dict the widget receives None instead of the object itself.

This makes crash some widgets like the DataGrid.
