### PR TITLE
exception value wasn't required and breaks compatibility with Python2.5

### DIFF
--- a/tw2/core/i18n.py
+++ b/tw2/core/i18n.py
@@ -16,7 +16,7 @@ def tw2_translation_string(sval):
 
         try:
             return core.request_local()['middleware'].config.translator(_sval)
-        except TypeError as e:
+        except TypeError:
             log.warn(traceback.format_exc())
             return _sval
 


### PR DESCRIPTION
While preparing TG2.2 beta release our Jenkins reported that tw2 breaks compatibility with Python 2.5

The issue was reported due to this exception handeling which actually seems not to require the exception value at all.
