### PR TITLE
Fix required Keyword for Date*Validators

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -423,6 +423,10 @@ class TestDateValidator(tb.ValidatorTest):
     to_python_params =   ['01/01/2009', 'asdf']
     to_python_expected = [datetime.date(2009, 1, 1), ValidationError]
 
+    attrs = [{'required': False}, {'required': True}]
+    params = ['', '']
+    expected = [None, ValidationError]
+
     from_python_attrs = [{}, {}]
     from_python_params = [datetime.date(2009, 1, 1)]
     from_python_expected = ['01/01/2009']
@@ -442,6 +446,10 @@ class TestDatetimeValidator(tb.ValidatorTest):
     to_python_attrs =    [{}, {}]
     to_python_params =   ['01/01/2009 01:00', 'asdf']
     to_python_expected = [datetime.datetime.strptime('1/1/2009 1:00', '%d/%m/%Y %H:%M'), ValidationError]
+
+    attrs = [{'required': False}, {'required': True}]
+    params = ['', '']
+    expected = [None, ValidationError]
 
     from_python_attrs = [{}, {}]
     from_python_params = [datetime.datetime.strptime('1/1/2009 1:00', '%d/%m/%Y %H:%M')]

--- a/tw2/core/validation.py
+++ b/tw2/core/validation.py
@@ -412,11 +412,18 @@ class DateValidator(RangeValidator):
 
     def to_python(self, value):
         value = super(DateValidator, self).to_python(value)
+        if not value:
+            return None
         try:
             date = time.strptime(value, self.format)
             return datetime.date(date.tm_year, date.tm_mon, date.tm_mday)
         except ValueError:
             raise ValidationError('baddate', self)
+
+    def validate_python(self, value, state):
+        super(DateValidator, self).validate_python(value, state)
+        if self.required and not value:
+            raise ValidationError('required', self)
 
     def from_python(self, value):
         return value and value.strftime(self.format) or ''
@@ -434,8 +441,8 @@ class DateTimeValidator(DateValidator):
     format = '%d/%m/%Y %H:%M'
 
     def to_python(self, value):
-        if value is None:
-            return value
+        if not value:
+            return None
         try:
             return datetime.datetime.strptime(value, self.format)
         except ValueError:


### PR DESCRIPTION
https://github.com/toscawidgets/tw2.forms/issues/8

I tried writing tests, but they are failing, I don't know why:

`TypeError: validate_python() takes exactly 3 arguments (2 given)`
