### PR TITLE
Make rendering_extension_lookup propagate up to templating layer

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -164,3 +164,18 @@ class TestTemplate(object):
         test_dir = os.path.sep.join(__file__.split(os.path.sep)[:-1])
         fname = os.path.sep.join([test_dir, 'test.html'])
         twc.Widget(template='genshi_abs:%s' % fname).display()
+
+    def test_rendering_extension_propagation(self):
+        mw = twc.make_middleware(None, preferred_rendering_engines=['genshi', 'jinja'],
+                                       rendering_extension_lookup={'genshi':['genshi', 'html'],
+                                                                   'jinja':['jinja']})
+        assert twc.templating.get_engine_name('tw2.core.test_templates.parent_genshi', mw) == 'genshi'
+
+        #flush caches to avoid wrong results due to cached results
+        twc.util.flush_memoization()
+        twc.templating.engine_name_cache = {}
+
+        mw = twc.make_middleware(None, preferred_rendering_engines=['genshi', 'jinja'],
+                                       rendering_extension_lookup={'genshi':['genshi'],
+                                                                   'jinja':['jinja', 'html']})
+        assert twc.templating.get_engine_name('tw2.core.test_templates.parent_genshi', mw) == 'jinja'

--- a/tw2/core/middleware.py
+++ b/tw2/core/middleware.py
@@ -116,8 +116,10 @@ class Config(object):
     rendering_extension_lookup = {
         'mako': ['mak', 'mako'],
         'genshi': ['genshi', 'html'],
+        'genshi_abs': ['genshi', 'html'], # just for backwards compatibility with tw2 2.0.0
         'jinja':['jinja', 'html'],
         'kajiki':['kajiki', 'html'],
+        'chameleon': ['pt']
     }
     script_name = ''
 

--- a/tw2/core/testbase/base.py
+++ b/tw2/core/testbase/base.py
@@ -175,8 +175,7 @@ class WidgetTest(object):
     declarative = False
     validate_params = None
     wrap = False
-
-    engines = templating.rendering_extension_lookup.keys()
+    engines = templating._default_rendering_extension_lookup.keys()
 
     def request(self, requestid, mw=None):
         if mw is None:
@@ -204,7 +203,7 @@ class WidgetTest(object):
         return self.request(1)
 
     def _get_all_possible_engines(self):
-        for engine in templating.rendering_extension_lookup:
+        for engine in templating._default_rendering_extension_lookup:
             yield engine
 
     def _check_rendering_vs_expected(self, engine, attrs, params, expected):


### PR DESCRIPTION
This provides a work-around for issue #32 making possible to change the rendering extensions to avoid collisions. Anyway a better default without collision should probably be provided by tw2.core itself.
