### PR TITLE
Use util.relpath instead of os.path.relpath.

### DIFF
--- a/tw2/core/templating.py
+++ b/tw2/core/templating.py
@@ -135,7 +135,7 @@ def get_render_callable(engine_name, displays_on, src, filename=None):
         args = dict(text=src)
 
         if filename:
-            args['filename'] = os.path.relpath(filename, directory)
+            args['filename'] = relpath(filename, directory)
             from mako.lookup import TemplateLookup
             args['lookup'] = TemplateLookup(
                 directories=[directory])

--- a/tw2/core/util.py
+++ b/tw2/core/util.py
@@ -137,8 +137,6 @@ except ImportError:
             start = os.curdir
         if not path:
             raise ValueError("no path specified")
-
-        # This may not work on windows.  See http://bit.ly/LT4rBP
         start_list = op.abspath(start).split(op.sep)
         path_list = op.abspath(path).split(op.sep)
 


### PR DESCRIPTION
Small fix concerning issue #30.
