### PR TITLE
Fix issue with deferred parameters getting lost when __new__ gets called multiple times

### DIFF
--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -236,7 +236,7 @@ class Widget(pm.Parametered):
                 )
 
         cls.resources = [r(parent=cls) for r in cls.resources]
-        cls._deferred = [k for k, v in cls.__dict__.iteritems()
+        cls._deferred = [k for k, v in inspect.getmembers(cls)
                          if isinstance(v, pm.Deferred)]
         cls._attr = [p.name for p in cls._params.values() if p.attribute]
 


### PR DESCRIPTION
This fixes the issue that deferred parameters gets lost when calling **new** again:

``` python
>>> w = twf.TextField(value=Deferred(lambda:1))
>>> w.display()
<input value="1" type="text" />
>>> w = w()
>>> w.display()
<input type="text" value="&lt;Deferred: &lt;Deferred&gt;&gt;" />
```
