### PR TITLE
avoid issues with unicode error messages

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -78,6 +78,16 @@ class TestValidation(TestCase):
         except twc.ValidationError:
             pass
 
+    def test_unicode_catch_errors(self):
+        try:
+            formencode.api.set_stdtranslation(languages=['tr'])
+            twc.validation.catch_errors(lambda s, x: formencode.validators.Int.to_python(x))(None, 'x')
+            assert(False)
+        except twc.ValidationError:
+            pass
+        finally:
+            formencode.api.set_stdtranslation(languages=['en'])
+
     def test_unflatten(self):
         assert(twc.validation.unflatten_params({'a':1, 'b:c':2}) ==
             {'a':1, 'b':{'c':2}})

--- a/tw2/core/validation.py
+++ b/tw2/core/validation.py
@@ -94,9 +94,10 @@ def catch_errors(fn):
             d = fn(self, *args, **kw)
             return d
         except catch, e:
+            e_msg = unicode(e)
             if self:
-                self.error_msg = str(e)
-            raise ValidationError(str(e), widget=self)
+                self.error_msg = e_msg
+            raise ValidationError(e_msg, widget=self)
     return wrapper
 
 


### PR DESCRIPTION
Seems that when validation errors are reported in languages with unicode characters that results into a crash
