### PR TITLE
Add proper escaping for JS and CSS sources

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -266,6 +266,53 @@ class TestJsFuncall(tb.WidgetTest):
             r = self.widget(**self.attrs).display(template='%s:%s' % (t, twr._JSFuncCall.template))
             assert r == """<script type="text/javascript">foo("a", "b")</script>""", r
 
+class TestJSSourceEscaping(tb.WidgetTest):
+    widget = twr.JSSource
+    attrs = {}
+    expected = None
+
+    def test_display(self):
+        s = twr.JSSource(src='''
+function test(a, b) {
+    if (b < 5)
+        return b;
+    else
+        return "OK";
+}
+''')
+        r = s.req()
+        displays = []
+        for e in self._get_all_possible_engines():
+            displays.append(r.display(template='%s:%s' % (e, twr.JSSource.template)))
+
+        compare_to = str(displays[0]).strip()
+        equal_displays = filter(lambda x:str(x).strip()==compare_to, displays)
+        assert len(displays) == len(equal_displays), equal_displays
+
+class TestCSSSourceEscaping(tb.WidgetTest):
+    widget = twr.CSSSource
+    attrs = {}
+    expected = None
+
+    def test_display(self):
+        s = twr.CSSSource(src='''
+p > strong:after {
+    content:"WOAH, this was STRONG!";
+}
+''')
+
+        r = s.req()
+        displays = []
+        for e in self._get_all_possible_engines():
+            #CSSource misses pt template.
+            if e in ['chameleon']:
+                continue
+            displays.append(r.display(template='%s:%s' % (e, twr.CSSSource.template)))
+
+        compare_to = str(displays[0]).strip()
+        equal_displays = filter(lambda x:str(x).strip()==compare_to, displays)
+        assert len(displays) == len(equal_displays), equal_displays
+
 from pkg_resources import Requirement
 class TestResourcesApp:
 

--- a/tw2/core/resources.py
+++ b/tw2/core/resources.py
@@ -234,7 +234,7 @@ class JSSource(Resource):
         super(JSSource, self).prepare()
         if not self.src:
             raise ValueError("%r must be provided a 'src' attr" % self)
-
+        self.src = Markup(self.src)
 
 class CSSSource(Resource):
     """
@@ -251,7 +251,7 @@ class CSSSource(Resource):
         super(CSSSource, self).prepare()
         if not self.src:
             raise ValueError("%r must be provided a 'src' attr" % self)
-
+        self.src = Markup(self.src)
 
 class _JSFuncCall(JSSource):
     """
@@ -277,7 +277,7 @@ class _JSFuncCall(JSSource):
             elif self.args:
                 args = ', '.join(encoder.encode(a) for a in self.args)
 
-            self.src = Markup('%s(%s)' % (self.function, args))
+            self.src = '%s(%s)' % (self.function, args)
         super(_JSFuncCall, self).prepare()
 
     def __hash__(self):


### PR DESCRIPTION
Also make sure that they behave the same with all the template engines.
Previously with escaping enabled they would escape things differently and
before enabling escaping Genshi and Kajiki escaped the sources while
Jinja and Mako didn't, exposing an inconsistent behavior when writing widgets
