### PR TITLE
Do not translate empty strings, this does not work.

### DIFF
--- a/tw2/core/validation.py
+++ b/tw2/core/validation.py
@@ -180,7 +180,7 @@ class Validator(object):
         'required': _('Enter a value'),
         'decode': _('Received in wrong character set; should be $encoding'),
         'corrupt': _('Form submission received corrupted; please try again'),
-        'childerror': _(''),  # Children of this widget have errors
+        'childerror': '',  # Children of this widget have errors
     }
     required = False
     strip = True


### PR DESCRIPTION
In the validation module, an empty string for child errors is translated with getext. This creates funny error messages of widgets with children, since it is a convention that gettext returns the translation metadata when passed an empty string.
