### PR TITLE
Simplify the validator API and make it compatible with FormEncode (#65).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.pyo
 *.egg*
 Thumbs.db
 docs/.output/
@@ -6,6 +7,7 @@ docs/.output/
 .noseids
 .project
 .pydevproject
+.settings
 html
 dist
 build

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -429,7 +429,7 @@ If a field has no value, if defaults to ``None``. It is down to that field's val
 
 **Security Consideration**
 
-When a widget is redisplayed after a validation failure, it's value is derived from unvalidated user input. This means widgets must be "safe" for all input values. In practice, this is almost always the case without great care, so widgets are assumed to be safe. 
+When a widget is redisplayed after a validation failure, it's value is derived from unvalidated user input. This means widgets must be "safe" for all input values. In practice, this is almost always the case without great care, so widgets are assumed to be safe.
 
 .. warning::
     If a particular widget is not safe in this way, it must override :meth:`_validate` and set :attr:`value` to *None* in case of error.
@@ -460,7 +460,7 @@ Earlier versions of ToscaWidgets used FormEncode for validation and there are go
 
 However, there are challenges making FormEncode and ToscaWidgets work together. For example, both libraries store the widget hierarchy internally. This makes implementing some features (e.g. ``strip_name`` and :class:`tw2.dynforms.HidingSingleSelectField`) difficult. There are different needs for the handling of unicode, leading ToscaWidgets to override some behaviour. Also, FormEncode just does not support client-side validation, a planned feature of ToscaWidgets 2.
 
-ToscaWidgets 2 does not rely on FormEncode. However, developers can use FormEncode validators for individual fields. The API is compatible in that :meth:`to_python` and :meth:`from_python` are called for conversion, and :class:`formencode.Invalid` is caught. Also, if FormEncode is installed, the :class:`ValidationError` class is a subclass of :class:`formencode.Invalid`.
+ToscaWidgets 2 does not rely on FormEncode. However, developers can use FormEncode validators for individual fields. The API is compatible in that :meth:`to_python` and :meth:`from_python` are called for conversion and validation, and :class:`formencode.Invalid` is caught. Also, if FormEncode is installed, the :class:`ValidationError` class is a subclass of :class:`formencode.Invalid`.
 
 
 Using Validators
@@ -495,7 +495,7 @@ A two-pass approach is used internally, although this is generally hidden from t
 
 .. autofunction:: tw2.core.validation.unflatten_params
 
-If this fails, there is no attempt to determine which parameter failed; the whole submission is considered corrupt. If the root widget has an ``id``, this is stripped from the dictionary, e.g. ``{'myid': {'param':'value', ...}}`` is converted to ``{'param':'value', ...}``. A widget instance is created, and stored in request local storage. This allows compatibility with existing frameworks, e.g. the ``@validate`` decorator in TurboGears. There is a hook in :meth:`display` that detects the request local instance. After creating the instance, validate works recursively, using the :meth:`_validate`. 
+If this fails, there is no attempt to determine which parameter failed; the whole submission is considered corrupt. If the root widget has an ``id``, this is stripped from the dictionary, e.g. ``{'myid': {'param':'value', ...}}`` is converted to ``{'param':'value', ...}``. A widget instance is created, and stored in request local storage. This allows compatibility with existing frameworks, e.g. the ``@validate`` decorator in TurboGears. There is a hook in :meth:`display` that detects the request local instance. After creating the instance, validate works recursively, using the :meth:`_validate`.
 
 .. automethod:: tw2.core.Widget._validate
 
@@ -503,7 +503,7 @@ If this fails, there is no attempt to determine which parameter failed; the whol
 
 .. automethod:: tw2.core.CompoundWidget._validate
 
-Both :meth:`_validate` and :meth:`validate_python` take an optional state argument. :class:`CompoundWidget` and :class:`RepeatingWidget` pass the partially built dict/list to their child widgets as state. This is useful for creating validators like :class:`MatchValidator` that reference sibling values. If one of the child widgets fails validation, the slot is filled with an :class:`Invalid` instance.
+Both :meth:`_validate` and :meth:`to_python` take an optional state argument. :class:`CompoundWidget` and :class:`RepeatingWidget` pass the partially built dict/list to their child widgets as state. This is useful for creating validators like :class:`MatchValidator` that reference sibling values. If one of the child widgets fails validation, the slot is filled with an :class:`Invalid` instance.
 
 
 General Considerations

--- a/tests/test_deep.txt
+++ b/tests/test_deep.txt
@@ -8,7 +8,7 @@
 ...
 >>> A.children[1]._sub_compound
 True
->>> a = A.req(value={'a':'1','b':'2','c':'3'})
+>>> a = A.req(value={'a':'1', 'b':'2', 'c':'3'})
 >>> a.prepare()
 >>> a.c.a.value
 '1'
@@ -42,7 +42,7 @@ True
 True
 >>> B.children[1].child._sub_compound
 True
->>> b = B.req(value={'a':'1','b':'2','c':'3'})
+>>> b = B.req(value={'a':'1', 'b':'2', 'c':'3'})
 >>> b.prepare()
 >>> b.c.a.child.value
 '1'

--- a/tests/test_validators.txt
+++ b/tests/test_validators.txt
@@ -1,6 +1,8 @@
 >>> import tw2.core as twc
->>> twc.Validator().validate_python('')
->>> twc.Validator(required=True).validate_python('')
+
+>>> twc.Validator().to_python('')
+
+>>> twc.Validator(required=True).to_python('')
 Traceback (most recent call last):
     ...
 ValidationError: Enter a value
@@ -10,89 +12,142 @@ ValidationError: Enter a value
 >>> twc.Validator(strip=False).to_python(' a ')
 ' a '
 
->>> twc.LengthValidator(min=1).validate_python([])
+>>> twc.LengthValidator(min=1).to_python([])
+Traceback (most recent call last):
+    ...
+ValidationError: Enter a value
+
+>>> twc.LengthValidator(min=1).to_python([1])
+[1]
+
+>>> twc.LengthValidator(min=2).to_python([1])
 Traceback (most recent call last):
     ...
 ValidationError: Value is too short
->>> twc.LengthValidator(min=1).validate_python([1])
->>> twc.LengthValidator(max=2).validate_python([1,2])
->>> twc.LengthValidator(max=2).validate_python([1,2,3])
+
+>>> twc.LengthValidator(max=2).to_python([1, 2])
+[1, 2]
+
+>>> twc.LengthValidator(max=2).to_python([1, 2, 3])
 Traceback (most recent call last):
     ...
 ValidationError: Value is too long
 
->>> twc.StringLengthValidator(min=1).validate_python('')
-Traceback (most recent call last):
-    ...
-ValidationError: Must be at least 1 characters
->>> twc.StringLengthValidator(required=True).validate_python('')
+>>> twc.StringLengthValidator(min=1).to_python('')
 Traceback (most recent call last):
     ...
 ValidationError: Enter a value
->>> twc.StringLengthValidator(min=1).validate_python('a')
->>> twc.StringLengthValidator(max=2).validate_python('aa')
->>> twc.StringLengthValidator(max=2).validate_python('aaa')
+
+>>> twc.StringLengthValidator(required=False, min=1).to_python('')
+Traceback (most recent call last):
+    ...
+ValidationError: Enter a value
+
+>>> twc.StringLengthValidator(min=1).to_python('a')
+'a'
+>>> twc.StringLengthValidator(min=2).to_python('a')
+Traceback (most recent call last):
+    ...
+ValidationError: Must be at least 2 characters
+
+>>> twc.StringLengthValidator(max=2).to_python('aa')
+'aa'
+>>> twc.StringLengthValidator(max=2).to_python('aaa')
 Traceback (most recent call last):
     ...
 ValidationError: Cannot be longer than 2 characters
 
->>> twc.ListLengthValidator(min=1).validate_python([])
+>>> twc.ListLengthValidator(min=1).to_python([])
 Traceback (most recent call last):
     ...
-ValidationError: Select at least 1
->>> twc.ListLengthValidator(min=1).validate_python([1])
->>> twc.ListLengthValidator(max=2).validate_python([1,2])
->>> twc.ListLengthValidator(max=2).validate_python([1,2,3])
+ValidationError: Enter a value
+
+>>> twc.ListLengthValidator(min=1).to_python([1])
+[1]
+
+>>> twc.ListLengthValidator(min=2).to_python([1])
+Traceback (most recent call last):
+    ...
+ValidationError: Select at least 2
+
+>>> twc.ListLengthValidator(max=2).to_python([1, 2])
+[1, 2]
+
+>>> twc.ListLengthValidator(max=2).to_python([1, 2, 3])
 Traceback (most recent call last):
     ...
 ValidationError: Select no more than 2
 
 >>> twc.IntValidator().to_python('123')
 123
+
 >>> twc.IntValidator().to_python(' 123 ')
 123
+
 >>> twc.IntValidator().to_python('x')
 Traceback (most recent call last):
     ...
 ValidationError: Must be an integer
+
 >>> twc.IntValidator().to_python('') is None
 True
+
 >>> twc.IntValidator().to_python(None) is None
 True
+
 >>> twc.IntValidator().to_python(0)
 0
->>> twc.IntValidator(required=True).validate_python(None)
+
+>>> twc.IntValidator(required=True).to_python(None)
 Traceback (most recent call last):
     ...
 ValidationError: Enter a value
->>> twc.IntValidator(required=True).validate_python(0)
 
->>> twc.IntValidator(min=5).validate_python(4)
+>>> twc.IntValidator(required=True).to_python(0)
+0
+
+>>> twc.IntValidator(min=5).to_python(4)
 Traceback (most recent call last):
     ...
 ValidationError: Must be at least 5
->>> twc.IntValidator(min=5).validate_python(5)
->>> twc.IntValidator(max=5).validate_python(5)
->>> twc.IntValidator(max=5).validate_python(6)
+
+>>> twc.IntValidator(min=5).to_python(5)
+5
+
+>>> twc.IntValidator(max=5).to_python(5)
+5
+
+>>> twc.IntValidator(max=5).to_python(6)
 Traceback (most recent call last):
     ...
 ValidationError: Cannot be more than 5
+
 >>> twc.IntValidator().from_python(0)
 '0'
->>> twc.IntValidator().from_python(None) is None
-True
+
+>>> twc.IntValidator().from_python(None)
+''
 
 >>> twc.BoolValidator().to_python('')
-False
+
 >>> twc.BoolValidator().to_python('on')
 True
->>> twc.BoolValidator(required=True).validate_python(False)
+
+>>> twc.BoolValidator().to_python('off')
+False
+
+>>> twc.BoolValidator(required=True).to_python(None)
 Traceback (most recent call last):
     ...
 ValidationError: You must select this
 
->>> twc.EmailValidator().validate_python('paj@pajhome.org.uk')
->>> twc.EmailValidator().validate_python('paj')
+>>> twc.BoolValidator(required=True).to_python(False)
+False
+
+>>> twc.EmailValidator().to_python('paj@pajhome.org.uk')
+'paj@pajhome.org.uk'
+
+>>> twc.EmailValidator().to_python('paj')
 Traceback (most recent call last):
     ...
 ValidationError: Must be a valid email address
@@ -101,32 +156,49 @@ ValidationError: Must be a valid email address
 ...   pw = twc.Widget()
 ...   pw_conf = twc.Widget(validator=twc.MatchValidator('pw'))
 ...
->>> Test.validate({'pw':'fred'})
+
+>>> Test.validate({'pw': 'fred'})
 Traceback (most recent call last):
     ...
 ValidationError
->>> Test.validate({'pw':'fred', 'pw_conf':'fred'})
+
+>>> Test.validate({'pw_conf': 'fred'})
+Traceback (most recent call last):
+    ...
+ValidationError
+
+>>> Test.validate({'pw': 'fred', 'pw_conf': 'derf'})
+Traceback (most recent call last):
+    ...
+ValidationError
+
+>>> Test.validate({'pw': 'fred', 'pw_conf': 'fred'})
 {'pw_conf': u'fred', 'pw': u'fred'}
 
 >>> class Test(twc.CompoundWidget):
 ...   id = twc.Widget()
 ...   report = twc.Widget(key='id')
 ...
+
 >>> ins = Test.req()
+
 >>> ins._validate({'id':'test'})
-{'report': None, 'id': 'test'}
+{'id': 'test'}
+
 >>> ins.c.report.value
 'test'
 
 >>> class MyVal(twc.Validator):
-...   def validate_python(self, value, state):
+...   def _valid_python(self, value, state):
 ...     assert(state['a'] is twc.Invalid)
 ...
+
 >>> class Test(twc.CompoundWidget):
 ...    a = twc.Widget(validator=twc.IntValidator)
 ...    b = twc.Widget(validator=MyVal)
 ...
->>> Test.validate({'a':'x'})
+
+>>> Test.validate({'a': 'x'})
 Traceback (most recent call last):
     ...
 ValidationError

--- a/tests/test_vdwidget.txt
+++ b/tests/test_vdwidget.txt
@@ -2,9 +2,9 @@ Check that display classmethod picks up validated_widget in request local
 
 >>> import tw2.core as twc
 >>> w = twc.Widget(id='w', template='genshi:tw2.core.test_templates.field_genshi', validator=twc.EmailValidator())
->>> w.validate({'w':'fred'})
+>>> w.validate({'w': 'fred'})
 Traceback (most recent call last):
     ...
 ValidationError: Must be a valid email address
->>> w.display()
-u'<p>fred Must be a valid email address</p>'
+>>> str(w.display())
+'<p>fred Must be a valid email address</p>'

--- a/tests/test_widgets.txt
+++ b/tests/test_widgets.txt
@@ -14,15 +14,15 @@ AttributeError: type object 'Myclass' has no attribute 'id'
 >>> twc.Widget(id='10')
 Traceback (most recent call last):
     ...
-ParameterError: Not a valid identifier: '10'
+ParameterError: Not a valid W3C id: '10'
 >>> twc.Widget(id=':')
 Traceback (most recent call last):
     ...
-ParameterError: Not a valid identifier: ':'
+ParameterError: Not a valid W3C id: ':'
 >>> twc.Widget(id=' ')
 Traceback (most recent call last):
     ...
-ParameterError: Not a valid identifier: ' '
+ParameterError: Not a valid W3C id: ' '
 >>> twc.Widget(id='test10')
 <class 'tw2.core.params.Widget_s'>
 >>> print twc.Page.compound_id

--- a/tw2/core/testbase/base.py
+++ b/tw2/core/testbase/base.py
@@ -343,19 +343,19 @@ class ValidatorTest(object):
         return self.request(1)
 
     def _check_validation(self, attrs, params, expected,
-                          method='validate_python'):
+                          method='to_python'):
         vld = self.validator(**attrs)
         if isinstance(expected, type) and \
            issubclass(expected, (twc.ValidationError, fe.Invalid)):
             try:
-                if method == 'validate_python':
+                if method == 'to_python':
                     params = vld.to_python(params)
                 r = getattr(vld, method)(params)
             except expected:
                 # XXX: figure out test way to test validation message match
                 pass
             return
-        if method == 'validate_python':
+        if method == 'to_python':
             params = vld.to_python(params)
         r = getattr(vld, method)(params)
         eq_(r, expected)


### PR DESCRIPTION
It is now always sufficient to call to_python() in order to both convert
and validate a value. For subclassing validators, we use the new API of
FormEncode 1.3, i.e. _validate_python() instead of validate_python().
The old method method name is still supported, but prints a warning.
