### PR TITLE
Update widgets.py

### DIFF
--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -567,7 +567,8 @@ class CompoundWidget(Widget):
     """
     children = pm.Param(
         'Children for this widget. This must be an iterable, ' +
-        'each item of which is a Widget'
+        'each item of which is a Widget',
+        default = []
     )
     c = pm.Variable(
         "Alias for children",


### PR DESCRIPTION
The children parameter should be set to list as default (now it's not possible to append child widgets before the class is instantiated)
