### PR TITLE
CompoundWidget validation breaks formencode custom translation by not passing a valid state

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -197,6 +197,30 @@ class TestValidation(TestCase):
             assert 'Enter a value' not in ve.widget.error_msg
             assert 'childerror' not in ve.widget.error_msg
 
+    def test_compound_validation_formencode_custom_translation(self):
+        if not formencode:
+            if HAS_SKIP:
+                self.skipTest('formencode is not available')
+            else:
+                return  # Just pretend like we passed
+
+        class CompWidget(twc.CompoundWidget):
+            one = twc.Widget(validator=formencode.validators.NotEmpty())
+            two = twc.Widget(validator=formencode.validators.NotEmpty())
+            three = twc.Widget(validator=twc.Validator(required=True))
+
+        class ValidationState(object):
+            def _(s, *args, **kwargs):
+                return 'TRANSLATION'
+
+        try:
+            CompWidget.validate({}, state=ValidationState())
+            assert False, "Widget should not have validated."
+        except ValidationError as ve:
+            assert 'TRANSLATION' in ve.widget.children[0].error_msg
+            assert 'TRANSLATION' in ve.widget.children[1].error_msg
+            assert 'Enter a value' in ve.widget.children[2].error_msg
+
     def test_auto_unflatten(self):
         test = twc.CompoundWidget(id='a', children=[
             twc.Widget(id='b', validator=twc.Validator(required=True)),

--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -668,7 +668,7 @@ class CompoundWidget(Widget):
         # Validate compound children
         for c in (child for child in self.children if child._sub_compound):
             try:
-                data.update(c._validate(value, data))
+                data.update(c._validate(value, state))
             except vd.catch as e:
                 if hasattr(e, 'msg'):
                     c.error_msg = e.msg
@@ -678,7 +678,7 @@ class CompoundWidget(Widget):
         for c in (child for child in self.children if not child._sub_compound):
             d = value.get(c.key, '')
             try:
-                val = c._validate(d, data)
+                val = c._validate(d, state)
                 if val is not vd.EmptyField:
                     data[c.key] = val
             except vd.catch as e:
@@ -692,7 +692,7 @@ class CompoundWidget(Widget):
         exception_validator = self.validator
         if self.validator:
             try:
-                data = self.validator.to_python(data)
+                data = self.validator.to_python(data, state)
             except vd.catch as e:
                 # If it failed to validate, check if the error_dict has any
                 # messages pertaining specifically to this widget's children.


### PR DESCRIPTION
FormEncode uses state._ when available to perform translations. This is used by TurboGears (also Pylons did the same) to make Formencode use the same language as detected by the framework itself.

When using TW2 forms with formencode validatiors i18n support breaks because CompoundWidget pass a dictionary instead of state object as the state parameter of the validate method. So even if a state object with a _ method is provided it gets ignored by the validate method.

Provides test unit to expose the issue.
