### PR TITLE
MatchValidator broken due to CompoundWidget state

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -141,6 +141,24 @@ class TestValidation(TestCase):
         except ValidationError as ve:
             assert(ve.widget.error_msg == NeverValid.msgs['never'])
 
+    def test_compound_MatchValidator(self):
+        """Test that compound widgets validate with MatchValidator"""
+        class MatchyWidget(twc.CompoundWidget):
+            one = twc.Widget(validator=MatchValidator('two'))
+            two = twc.Widget
+
+        try:
+            MatchyWidget.validate({'one': 'foo', 'two': 'foo'})
+        except ValidationError as ve:
+            assert False, "Widget should have validated correctly."
+
+        try:
+            MatchyWidget.validate({'one': 'foo', 'two': 'bar'})
+            assert False, "Widget should not have validated."
+        except ValidationError as ve:
+            pass
+
+
     def test_compound_validation_formencode(self):
         """Test that compound widgets validate with formencode."""
 

--- a/tw2/core/util.py
+++ b/tw2/core/util.py
@@ -129,6 +129,18 @@ def flush_memoization():
         cb()
 
 
+def clone_object(obj, **values):
+    if obj is None:
+        obj = type('_TemporaryObject', (object,), {})()
+    else:
+        obj = copy.copy(obj)
+
+    for k,v in values.items():
+        setattr(obj, k, v)
+
+    return obj
+
+
 # relpath support for python-2.5
 # Taken from https://github.com/nipy/nipype/issues/62
 # Related to https://github.com/toscawidgets/tw2.core/issues/30

--- a/tw2/core/validation.py
+++ b/tw2/core/validation.py
@@ -616,7 +616,13 @@ class MatchValidator(Validator):
         return capitalize(util.name2label(self.other_field).lower())
 
     def _validate_python(self, value, state):
-        if self.other_field not in state or value != state[self.other_field]:
+        if isinstance(state, dict):
+            # Backward compatibility
+            values = state
+        else:
+            values = state.full_dict
+
+        if self.other_field not in values or value != values[self.other_field]:
             raise ValidationError('mismatch', self)
 
     def _is_empty(self, value):

--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -665,6 +665,8 @@ class CompoundWidget(Widget):
         any_errors = False
         data = {}
 
+        state = util.clone_object(state, full_dict=value, validated_values=data)
+
         # Validate compound children
         for c in (child for child in self.children if child._sub_compound):
             try:


### PR DESCRIPTION
Provides a test unit to expose that MatchValidator stopped working due to change in CompoundWidget now correctly passing a state when validating (this is required for compatibility on i18n with FormEncode). The proposed fix provides the values of the CompoundWidget inside the state when it gets validated. The values are available inside full_dict for coherence with FormEncode and states are copied before updating them to provide a stack of states instead of replacing the original one.
