### PR TITLE
Use mako's render_unicode method.

### DIFF
--- a/tw2/core/templating.py
+++ b/tw2/core/templating.py
@@ -146,7 +146,7 @@ def get_render_callable(engine_name, displays_on, src, filename=None, inline=Fal
                 directories=[directory])
 
         tmpl = mako.template.Template(**args)
-        return lambda kwargs: Markup(tmpl.render(**kwargs))
+        return lambda kwargs: Markup(tmpl.render_unicode(**kwargs))
 
     elif engine_name in ('genshi', 'genshi_abs'):
         import genshi.template


### PR DESCRIPTION
This avoids tw2 playing a role in unnecessarily coercing strings from
unicode to bytestrings and back again.  We can just keep things unicode
until the very last moment.