### PR TITLE
Don't use absolute resource path

### DIFF
--- a/tw2/core/i18n.py
+++ b/tw2/core/i18n.py
@@ -22,7 +22,7 @@ def get_localedir():
     locale_dir = ''
     if resource_filename is not None:
         try:
-            locale_dir = resource_filename(__name__, "/i18n")
+            locale_dir = resource_filename(__name__, "i18n")
         except NotImplementedError:
             pass
     if not hasattr(os, 'access'):


### PR DESCRIPTION
Right now, pkg_resources.resource_filename() emits warnings about
absolute resource paths, but this will raise an exception in the future.