### PR TITLE
fix templating encoding on some systems by using rb mode

### DIFF
--- a/tw2/core/templating.py
+++ b/tw2/core/templating.py
@@ -111,10 +111,7 @@ def get_source(engine_name, template, inline=False, mw=None):
         filename = _get_dotted_filename(engine_name, template, mw=mw)
 
     with open(filename, 'rb') as f:
-        if six.PY2:
-            return f.read()
-        else:
-            return f.read().decode('utf-8')
+        return f.read().decode('utf-8')
 
 
 @memoize
@@ -171,7 +168,7 @@ def get_render_callable(engine_name, displays_on, src, filename=None, inline=Fal
 
     elif engine_name == 'kajiki':
         import kajiki
-        tmpl = kajiki.XMLTemplate(six.u(src), filename=filename,
+        tmpl = kajiki.XMLTemplate(src, filename=filename,
                                   cdata_scripts=False)
         return lambda kwargs: Markup(tmpl(kwargs).render())
 

--- a/tw2/core/templating.py
+++ b/tw2/core/templating.py
@@ -111,7 +111,10 @@ def get_source(engine_name, template, inline=False, mw=None):
         filename = _get_dotted_filename(engine_name, template, mw=mw)
 
     with open(filename, 'rb') as f:
-        return f.read()
+        if six.PY2:
+            return f.read()
+        else:
+            return f.read().decode('utf-8')
 
 
 @memoize

--- a/tw2/core/templating.py
+++ b/tw2/core/templating.py
@@ -110,15 +110,8 @@ def get_source(engine_name, template, inline=False, mw=None):
     else:
         filename = _get_dotted_filename(engine_name, template, mw=mw)
 
-    # TODO -- use a context manager here once we drop support for py2.5.
-    f = open(filename, 'r')
-
-    try:
-        source = f.read()
-    finally:
-        f.close()
-
-    return source
+    with open(filename, 'rb') as f:
+        return f.read()
 
 
 @memoize


### PR DESCRIPTION
hello, when using templates that aren't inline, the file were opened in text mode, sometimes with encoding `UTF-8` sometimes with `ANSI_X3.4-1968`
the encoding used by open is got from `locale.getpreferredencoding()` that depends on `LANG` environment variable.
anyway if you open the file as binary instead of text, everything works flawless

ps: py2.5 is not supported anymore