### PR TITLE
fix and test inheritance of CompundWidgets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,11 @@ tests_require = [
     _extra_kajiki + \
     _extra_chameleon
 
+if sys.version_info[0] == 2 and sys.version_info[1] == 7:
+    tests_require.append('soupsieve<2.0')
+
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     tests_require.append('WebTest<2.0.0')
-if sys.version_info[0] == 2 and sys.version_info[1] == 7:
-    tests_require.append('WebTest<=2.0.34')  # due to soupsieve not installing on pypy
 else:
     tests_require.append('WebTest')
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 5:
 
 tests_require = [
     'nose',
-    'sieve==2.0',  # on pypy2.7, version 2.0.1 failed to install
+    'sieve < 2.0',  # on pypy2.7, version 2.0 failed to install
     'coverage',
     'Formencode >= 1.3.0 '
 ] + \

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 5:
 
 tests_require = [
     'nose',
-    'sieve',
+    'sieve==2.0',  # on pypy2.7, version 2.0.1 failed to install
     'coverage',
     'Formencode >= 1.3.0 '
 ] + \

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] <= 5:
 
 tests_require = [
     'nose',
-    'sieve < 2.0',  # on pypy2.7, version 2.0 failed to install
+    'sieve',
     'coverage',
     'Formencode >= 1.3.0 '
 ] + \
@@ -67,6 +67,8 @@ tests_require = [
 
 if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
     tests_require.append('WebTest<2.0.0')
+if sys.version_info[0] == 2 and sys.version_info[1] == 7:
+    tests_require.append('WebTest<=2.0.34')  # due to soupsieve not installing on pypy
 else:
     tests_require.append('WebTest')
 

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -88,7 +88,32 @@ class TestHierarchy(object):
         assert(test.children.b.value == 10)
         assert(test.children.c.value == 20)
 
+    def test_cw_duplicate(self):
+        try:
+            class Parent(twc.CompoundWidget):
+                class Left(twc.CompoundWidget):
+                    id = None
+                    c = twc.Widget()
 
+                class Right(twc.CompoundWidget):
+                    id = None
+                    c = twc.Widget()
+            assert False, 'Must raise'
+        except twc.WidgetError as ex:
+            assert "Duplicate id 'c'" in str(ex)
+
+    def test_cw_override(self):
+        class Grandpa(twc.CompoundWidget):
+            class Parent(twc.CompoundWidget):
+                a = twc.Widget(id='a', name='override_me')
+
+            class Child(Parent):
+                a = twc.Widget(id='a', name='A')
+                b = twc.Widget(id='b', name='B')
+        assert len(Grandpa.children.Child.children) == 2
+        assert Grandpa.children.Child.children[0].name == 'A'
+        assert Grandpa.children.Child.children[1].name == 'B'
+            
     #--
     # Repeating Widget Bunch
     #--

--- a/tw2/core/widgets.py
+++ b/tw2/core/widgets.py
@@ -590,8 +590,12 @@ class CompoundWidget(Widget):
         cls._sub_compound = not getattr(cls, 'id', None)
         if not hasattr(cls, 'children'):
             return
-        joined_cld = []
 
+        super_children_ids = []
+        if hasattr(super(cls, cls), 'children'):
+            super_children_ids = [c.id for c in super(cls, cls).children if hasattr(c, 'id')]
+
+        joined_cld = []
         for c in cls.children:
             if not isinstance(c, type) or not issubclass(c, Widget):
                 raise pm.ParameterError("All children must be widgets")
@@ -601,7 +605,9 @@ class CompoundWidget(Widget):
         for c in cls.children_deep():
             if getattr(c, 'id', None):
                 if c.id in ids:
-                    raise core.WidgetError("Duplicate id '%s'" % c.id)
+                    if c.id not in super_children_ids:
+                        raise core.WidgetError("Duplicate id '%s'" % c.id)
+                    joined_cld.pop([x.id for x in joined_cld].index(c.id))
                 ids.add(c.id)
         cls.children = WidgetBunch(joined_cld)
         cls.keyed_children = [


### PR DESCRIPTION
this is useful when you define forms like

```python
In [1]: import tw2.forms as twf

In [2]: from tw2.core.middleware import TwMiddleware

In [3]: application = TwMiddleware(lambda x: x)

In [4]: class F(twf.Form):
    class child(twf.ListLayout):
        a = twf.TextField()
   ...:         

In [5]: class FFF(twf.Form):
    class child(F.child):
        a = twf.HiddenField()
        b = twf.TextField()
   ...:         

In [6]: print(FFF.display())
<form enctype="multipart/form-data" method="post">
     <span class="error"></span>
    <ul >
    <input id="a" name="a" type="hidden"/>
    <li class="odd"id="b:container">
     <label for="b">B</label>
        <input id="b" name="b" type="text"/>
        <span id="b:error" class="error"></span>
    </li>
   <li class="error"><span id=":error" class="error">    </span></li>
</ul>

		<input value="Save" type="submit"/>
</form>


In [7]: ```